### PR TITLE
Fix: 좋아요 & 유저정보수정

### DIFF
--- a/Models/userModel.js
+++ b/Models/userModel.js
@@ -116,7 +116,8 @@ exports.editUser = async (nickname, profile_img, user_id) => {
         const userNickname = userData.users.find(
             (user) => user.nickname === nickname
         );
-        if (user_id != userNickname.user_id) return 400;
+
+        if (userNickname && user_id != userNickname.user_id) return 400;
 
         if (user.profile_img && profile_img) {
             const filePath = path.join(__dirname, '..', user.profile_img);

--- a/data/boardInfo.json
+++ b/data/boardInfo.json
@@ -44,7 +44,7 @@
             "board_date": "2024-12-05 11:19:37",
             "update_date": "2024-12-05 17:39:31",
             "like_count": 1,
-            "view_count": 92,
+            "view_count": 93,
             "comment_count": 1,
             "user_id": "2"
         }


### PR DESCRIPTION
1.좋아요 데이터를 저장하는 json 파일 업로드(기존에 없었음)
2.프론트에서는 닉네임을 바꾸든 이미지만 바꾸든 상관없이 닉네임값이 넘겨옴
때문에 아래와 같은 로직을 수행하도록 작성하였음

1.동일한 닉네임이 있는지 검사함 있을시 userNickanm에 유저 객체가 담김2.userNickname의 user_id와 수정요청한 user_id를 비교 3.user_id가 같을시 닉네임 변경을 하지 않는것으로 판단! 닉네임 중복에러 발생x

문제발생!! 닉네임을 변경시 userNickname에 값이 담기지 않아 에러를 발생함
해결방법 userNickname에 값이 담겨있는지 추가로 검사