### PR TITLE
Fix: 회원 탈퇴시 남아있는 게시글,댓글 처리

### DIFF
--- a/Models/userModel.js
+++ b/Models/userModel.js
@@ -165,6 +165,26 @@ exports.delUser = async (user_id) => {
             .promise()
             .query('SELECT * FROM user WHERE user_id = ?', [user_id]);
         if (rows.length > 0) {
+            // 연관된 데이터의 user_id를 NULL로 설정
+            await pool
+                .promise()
+                .query(
+                    'UPDATE boardLike SET user_id = NULL WHERE user_id = ?',
+                    [user_id]
+                );
+            await pool
+                .promise()
+                .query(
+                    'UPDATE boardInfo SET user_id = NULL WHERE user_id = ?',
+                    [user_id]
+                );
+            await pool
+                .promise()
+                .query('UPDATE comment SET user_id = NULL WHERE user_id = ?', [
+                    user_id,
+                ]);
+
+            // user 삭제
             const [result] = await pool
                 .promise()
                 .query('DELETE FROM user WHERE user_id = ?', [user_id]);


### PR DESCRIPTION
회원탈퇴시 남아있는 게시물,댓글,좋아요에 대하여 추후에 같은 이메일로 재가입하여도 수정,삭제가 불가능 하도록 user_id값을 null로 바뀌게 처리 하였음